### PR TITLE
Add a delegated touch event to track touchstart and touchend events

### DIFF
--- a/src/components/AppGrid.vue
+++ b/src/components/AppGrid.vue
@@ -28,6 +28,8 @@
       <section
         class="grid"
         :style="{ gridTemplateColumns: colTemplate, gridTemplateRows: rowTemplate , gridColumnGap: columngap + 'px', gridRowGap: rowgap + 'px' }"
+        @touchstart.prevent="delegatedTouchPlaceChild"
+        @touchend.prevent="delegatedTouchPlaceChild"
       >
         <div
           v-for="(item, i) in divNum"
@@ -99,6 +101,14 @@ export default {
         this.errors[direction].splice(this.errors[direction].indexOf(i), 1);
       }
     },
+
+    delegatedTouchPlaceChild(ev) {
+      const target = document.elementFromPoint(ev.changedTouches[0].clientX, ev.changedTouches[0].clientY);
+      const startend = ev.type === 'touchstart' ? 's' : 'e';
+      const id = Number(target.className.replace('box', '')) + 1;
+      this.placeChild(id, startend)
+    },
+
     placeChild(item, startend) {
       //built an object first because I might use this for something else
       this.child[`${startend}row`] = Math.ceil(item / this.columns);

--- a/src/components/AppGrid.vue
+++ b/src/components/AppGrid.vue
@@ -35,6 +35,7 @@
           v-for="(item, i) in divNum"
           :key="i"
           :class="'box' + i"
+          :data-id="item"
           @mousedown="placeChild(item, 's')"
           @mouseup="placeChild(item, 'e')"
         ></div>
@@ -105,10 +106,8 @@ export default {
     delegatedTouchPlaceChild(ev) {
       const target = document.elementFromPoint(ev.changedTouches[0].clientX, ev.changedTouches[0].clientY);
       const startend = ev.type === 'touchstart' ? 's' : 'e';
-      const id = Number(target.className.replace('box', '')) + 1;
-      this.placeChild(id, startend)
+      this.placeChild(target.dataset.id, startend)
     },
-
     placeChild(item, startend) {
       //built an object first because I might use this for something else
       this.child[`${startend}row`] = Math.ceil(item / this.columns);


### PR DESCRIPTION
Thanks for this tool Sarah, it's awesome! 

### Potential way to address #3 (Touch events)

_Disclaimer: I'm new to Vue, coming from the React world so I'm sure this isn't the "Vue" way to do it!_

#### Comments
Digging in a little and it seems the `touchend` will always report the same element as `touchstart`. This solution delegates the touch event listeners to the parent of the grid, then calculates the element from the TouchEvent's x and y.

Gleaning the item number from the class is a little messy, wasn't sure how else to pull it off!

#### Testing
Smoke tested through BrowserStack on iPhoneX and Google Pixel.


Thanks again for putting such a useful tool together!

