### PR TITLE
Fix: reverse start and end values when dragged in negative direction

### DIFF
--- a/src/components/AppGrid.vue
+++ b/src/components/AppGrid.vue
@@ -109,8 +109,18 @@ export default {
 
       //create the children css units as a string
       if (startend === "e") {
-        let childstring = `${this.child.srow} / ${this.child.scol} / ${this
-          .child.erow + 1} / ${this.child.ecol + 1}`;
+        // flip starts and ends if dragged in the opposite direction
+        let [startRow, endRow] =
+          this.child.srow <= this.child.erow
+            ? [this.child.srow, this.child.erow]
+            : [this.child.erow, this.child.srow];
+        let [startCol, endCol] =
+          this.child.scol <= this.child.ecol
+            ? [this.child.scol, this.child.ecol]
+            : [this.child.ecol, this.child.scol];
+
+        let childstring = `${startRow} / ${startCol} / ${endRow +
+          1} / ${endCol + 1}`;
 
         this.$store.commit("addChildren", childstring);
       }


### PR DESCRIPTION
Hello! 👋 

This should resolve #8, flipping the start/end values for row or column if dragged in a negative direction.

The grid code displayed after a drag in a negative direction was also incorrect in those situations, that is fixed here.

Thanks for the great resource!