### PR TITLE
unit validation improvement

### DIFF
--- a/src/components/AppGrid.vue
+++ b/src/components/AppGrid.vue
@@ -86,14 +86,14 @@ export default {
     validateunit(e, i, direction) {
       let unit = e.target.value;
       let check =
-        /fr/.test(unit) ||
-        /px/.test(unit) ||
-        /%/.test(unit) ||
-        /em/.test(unit) ||
-        /rem/.test(unit) ||
-        /vw/.test(unit) ||
-        /vh/.test(unit) ||
-        /vmin/.test(unit);
+        /fr$/.test(unit) ||
+        /px$/.test(unit) ||
+        /%$/.test(unit) ||
+        /em$/.test(unit) ||
+        /rem$/.test(unit) ||
+        /vw$/.test(unit) ||
+        /vh$/.test(unit) ||
+        /vmin$/.test(unit);
 
       if (!check) {
         this.errors[direction].push(i);


### PR DESCRIPTION
Added `$` to the end of unit validation regex strings. 
For example, this will match `5fr` but not `5fra`