### PR TITLE
Allow 0 as a valid value without a unit

### DIFF
--- a/src/components/AppGrid.vue
+++ b/src/components/AppGrid.vue
@@ -93,7 +93,8 @@ export default {
         /rem/.test(unit) ||
         /vw/.test(unit) ||
         /vh/.test(unit) ||
-        /vmin/.test(unit);
+        /vmin/.test(unit) ||
+        parseInt(unit, 10) === 0; // allow 0 as a valid value without a unit
 
       if (!check) {
         this.errors[direction].push(i);


### PR DESCRIPTION
Fixes issue https://github.com/sdras/cssgridgenerator/issues/43

Allows users to enter `0` as a value without a unit because that’s a valid CSS value.

Thanks for building this, Sarah! Feel free to suggest changes or reject my PR if you think this behavior shouldn’t be allowed.