### PR TITLE
Fixed the maximum height of the modal window

### DIFF
--- a/src/components/AppCode.vue
+++ b/src/components/AppCode.vue
@@ -103,7 +103,7 @@ export default {
   border: 1px solid #08ffbd;
   font-size: 15px;
   font-family: "Roboto Mono", Courier, monospace;
-  max-height: 70vh;
+  max-height: 50vh;
   overflow-y: scroll;
   p {
     margin: 5px;


### PR DESCRIPTION
Fixed the maximum height of the modal window when a lot of code

<img width="128" alt="Снимок экрана 2019-06-01 в 15 49 53" src="https://user-images.githubusercontent.com/2853419/58748712-5bf7e400-8485-11e9-9d5a-388b0dbb767f.png"> <img width="128" alt="Снимок экрана 2019-06-01 в 15 50 00" src="https://user-images.githubusercontent.com/2853419/58748724-69ad6980-8485-11e9-9e39-d13e0d67b157.png"> <img width="128" alt="Снимок экрана 2019-06-01 в 15 50 47" src="https://user-images.githubusercontent.com/2853419/58748727-6d40f080-8485-11e9-83a2-0ab725f09839.png">
