### PR TITLE
Add css repeat() support

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -2,28 +2,30 @@ import Vue from "vue";
 import Vuex from "vuex";
 
 Vue.use(Vuex);
-const groupRepeatedUnits = (templateArray = ['1fr']) => {
+const groupRepeatedUnits = (templateArray = ["1fr"]) => {
   const groups = [[templateArray.shift()]];
   for (const templateUnit of templateArray) {
-    const lastGroup = groups[groups.length - 1]
+    const lastGroup = groups[groups.length - 1];
     if (lastGroup.indexOf(templateUnit) !== -1) {
       lastGroup.push(templateUnit);
-      continue;
+    } else {
+      groups.push([templateUnit]);
     }
-    groups.push([templateUnit]);
   }
   return groups;
-}
+};
 
 const createRepetition = (groups, maxRepetition = 1) => {
-  return groups.map(group =>
-    // If you want to add repetition only when a measure is repeated more than 1 time,
-    // change maxRepetition value
-    group.length === maxRepetition
-      ? group.join(' ')
-      : `repeat(${group.length}, ${group[0]})`
-  ).join(' ');
-}
+  return groups
+    .map(group =>
+      // If you want to add repetition only when a measure is repeated more than 1 time,
+      // change maxRepetition value
+      group.length === maxRepetition
+        ? group.join(" ")
+        : `repeat(${group.length}, ${group[0]})`
+    )
+    .join(" ");
+};
 
 export default new Vuex.Store({
   state: {
@@ -33,7 +35,7 @@ export default new Vuex.Store({
     rowgap: 0,
     colArr: [],
     rowArr: [],
-    childarea: [],
+    childarea: []
   },
   getters: {
     colTemplate(state) {
@@ -70,7 +72,7 @@ export default new Vuex.Store({
       } else {
         let difference = newVal - oldVal;
         for (let i = 1; i <= difference; i++) {
-          state[payload.direction].push({unit: "1fr"});
+          state[payload.direction].push({ unit: "1fr" });
         }
       }
     },
@@ -101,6 +103,6 @@ export default new Vuex.Store({
 //we start off with just a few rows and columns filled with 1fr units
 const createArr = (direction, arr) => {
   for (let i = 1; i <= direction; i++) {
-    arr.push({unit: "1fr"});
+    arr.push({ unit: "1fr" });
   }
 };

--- a/src/store.js
+++ b/src/store.js
@@ -1,31 +1,8 @@
 import Vue from "vue";
 import Vuex from "vuex";
+import { groupRepeatedUnits, createRepetition } from "./utils/repetition";
 
 Vue.use(Vuex);
-const groupRepeatedUnits = (templateArray = ["1fr"]) => {
-  const groups = [[templateArray.shift()]];
-  for (const templateUnit of templateArray) {
-    const lastGroup = groups[groups.length - 1];
-    if (lastGroup.indexOf(templateUnit) !== -1) {
-      lastGroup.push(templateUnit);
-    } else {
-      groups.push([templateUnit]);
-    }
-  }
-  return groups;
-};
-
-const createRepetition = (groups, maxRepetition = 1) => {
-  return groups
-    .map(group =>
-      // If you want to add repetition only when a measure is repeated more than 1 time,
-      // change maxRepetition value
-      group.length === maxRepetition
-        ? group.join(" ")
-        : `repeat(${group.length}, ${group[0]})`
-    )
-    .join(" ");
-};
 
 export default new Vuex.Store({
   state: {
@@ -39,15 +16,11 @@ export default new Vuex.Store({
   },
   getters: {
     colTemplate(state) {
-      // Maybe this mapping can be executed inside groupRepeatedUnits
-      // to avoid code repetition
-      const templateArray = state.colArr.map(i => i["unit"]);
-      const unitGroups = groupRepeatedUnits(templateArray);
+      const unitGroups = groupRepeatedUnits(state.colArr);
       return createRepetition(unitGroups);
     },
     rowTemplate(state) {
-      const templateArray = state.rowArr.map(i => i["unit"]);
-      const unitGroups = groupRepeatedUnits(templateArray);
+      const unitGroups = groupRepeatedUnits(state.rowArr);
       return createRepetition(unitGroups);
     },
     divNum(state) {

--- a/src/store.js
+++ b/src/store.js
@@ -3,16 +3,16 @@ import Vuex from "vuex";
 
 Vue.use(Vuex);
 const groupRepeatedUnits = (templateArray = ['1fr']) => {
-  const groups = [[templateArray.shift()]]
+  const groups = [[templateArray.shift()]];
   for (const templateUnit of templateArray) {
     const lastGroup = groups[groups.length - 1]
     if (lastGroup.indexOf(templateUnit) !== -1) {
-      lastGroup.push(templateUnit)
-      continue
+      lastGroup.push(templateUnit);
+      continue;
     }
-    groups.push([templateUnit])
+    groups.push([templateUnit]);
   }
-  return groups
+  return groups;
 }
 
 const createRepetition = (groups, maxRepetition = 1) => {
@@ -22,7 +22,7 @@ const createRepetition = (groups, maxRepetition = 1) => {
     group.length === maxRepetition
       ? group.join(' ')
       : `repeat(${group.length}, ${group[0]})`
-  ).join(' ')
+  ).join(' ');
 }
 
 export default new Vuex.Store({

--- a/src/store.js
+++ b/src/store.js
@@ -2,6 +2,28 @@ import Vue from "vue";
 import Vuex from "vuex";
 
 Vue.use(Vuex);
+const groupRepeatedUnits = (templateArray = ['1fr']) => {
+  const groups = [[templateArray.shift()]]
+  for (const templateUnit of templateArray) {
+    const lastGroup = groups[groups.length - 1]
+    if (lastGroup.indexOf(templateUnit) !== -1) {
+      lastGroup.push(templateUnit)
+      continue
+    }
+    groups.push([templateUnit])
+  }
+  return groups
+}
+
+const createRepetition = (groups, maxRepetition = 1) => {
+  return groups.map(group =>
+    // If you want to add repetition only when a measure is repeated more than 1 time,
+    // change maxRepetition value
+    group.length === maxRepetition
+      ? group.join(' ')
+      : `repeat(${group.length}, ${group[0]})`
+  ).join(' ')
+}
 
 export default new Vuex.Store({
   state: {
@@ -15,10 +37,16 @@ export default new Vuex.Store({
   },
   getters: {
     colTemplate(state) {
-      return state.colArr.map(i => i["unit"]).join(" ");
+      // Maybe this mapping can be executed inside groupRepeatedUnits
+      // to avoid code repetition
+      const templateArray = state.colArr.map(i => i["unit"]);
+      const unitGroups = groupRepeatedUnits(templateArray);
+      return createRepetition(unitGroups);
     },
     rowTemplate(state) {
-      return state.rowArr.map(i => i["unit"]).join(" ");
+      const templateArray = state.rowArr.map(i => i["unit"]);
+      const unitGroups = groupRepeatedUnits(templateArray);
+      return createRepetition(unitGroups);
     },
     divNum(state) {
       return state.columns * state.rows;

--- a/src/utils/repetition.js
+++ b/src/utils/repetition.js
@@ -15,8 +15,8 @@ export const groupRepeatedUnits = (templateUnitArray = [{ unit: "1fr" }]) => {
 export const createRepetition = (groups, maxRepetition = 1) => {
   return groups
     .map(group =>
-      // If you want to add repetition only when a measure is repeated more than once,
-      // change maxRepetition value
+      // If you want to add repetition only when a measure is repeated more than x times,
+      // change maxRepetition value to x
       group.length === maxRepetition
         ? group.join(" ")
         : `repeat(${group.length}, ${group[0]})`

--- a/src/utils/repetition.js
+++ b/src/utils/repetition.js
@@ -1,0 +1,25 @@
+export const groupRepeatedUnits = (templateUnitArray = [{ unit: "1fr" }]) => {
+  const templateArray = templateUnitArray.map(i => i["unit"]);
+  const groups = [[templateArray.shift()]];
+  for (const templateUnit of templateArray) {
+    const lastGroup = groups[groups.length - 1];
+    if (lastGroup.indexOf(templateUnit) !== -1) {
+      lastGroup.push(templateUnit);
+    } else {
+      groups.push([templateUnit]);
+    }
+  }
+  return groups;
+};
+
+export const createRepetition = (groups, maxRepetition = 1) => {
+  return groups
+    .map(group =>
+      // If you want to add repetition only when a measure is repeated more than once,
+      // change maxRepetition value
+      group.length === maxRepetition
+        ? group.join(" ")
+        : `repeat(${group.length}, ${group[0]})`
+    )
+    .join(" ");
+};


### PR DESCRIPTION
First, thanks for creating this website. 
It's very nice to have this utility and I'll probably use it a lot when creating layouts.

## Motivation
When using css grid, one of the css features that can be used is the function repeat()
when you have lots of columns or rows. 

Adding support to this function would help the developer know the number of columns / rows
only by first looking at the repeat first argument (the number of repetitions).

For example:
```css
/* I'm CoNfUsEd(???) How many columns are there??? */
.selector {
  grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr 100px;
}
```
would be translated to
```css
/* YEEAH now I get it! there're 6 fraction columns + 1 100px column */
.selector {
  grid-template-columns: repeat(6, 1fr) 100px;
}
```

## What is included in this PR?
This PR adds two functions:

- groupRepeatedUnits (templateArray = ['1fr'])
this function iterates over the template array and creates a matrix in a format like
`[['1fr', '1fr'], ['100px']]` when passed `['1fr', '1fr', '100px']` as argument.

- createRepetition (groups, maxRepetition = 1)
this function expects a data model like the one `groupRepeatedUnits` returned and
maps and joins it in a final format like `'repeat(2, '1fr') 100px'`. **Note**: it expects a second arg called maxRepetition, which controls the max number of repetitions before adding a repeat() in the array. If you think we should only add repeat() for 2+ repetitions just increase this argument default value.

I chose the 2-functions implementation over a simple function that creates only one array in favor of cleaner code. This because a single function would add complexity and nested ifs. If you know a better implementation, please share with me.