### PR TITLE
 Transition columns, rows and gaps (2)

### DIFF
--- a/src/components/AppGrid.vue
+++ b/src/components/AppGrid.vue
@@ -235,6 +235,10 @@ main {
   position: absolute;
   display: grid;
   grid-auto-flow: row dense;
+  transition: 0.5s grid-template-columns ease-in-out, 
+            0.5s grid-template-rows ease-in-out, 
+            0.5s gap ease-in-out;  
+              
   @include colors(20, 100);
   p {
     padding: 0 10px;

--- a/src/components/AppGrid.vue
+++ b/src/components/AppGrid.vue
@@ -235,10 +235,10 @@ main {
   position: absolute;
   display: grid;
   grid-auto-flow: row dense;
-  transition: 0.5s grid-template-columns ease-in-out, 
-            0.5s grid-template-rows ease-in-out, 
-            0.5s gap ease-in-out;  
-              
+  transition: 0.3s grid-template-columns ease-in-out, 
+            0.3s grid-template-rows ease-in-out, 
+            0.3s gap ease-in-out;  
+
   @include colors(20, 100);
   p {
     padding: 0 10px;


### PR DESCRIPTION
Hi! 

Thanks for reviewing #35. I've updated it so that it is now 0.3 seconds as you requested, and applied it to the correct element.

You recommended that I use a `transition` element for this to work, but I have tested it with just CSS, and it works in Firefox. Transitioning grid properties is not supported in Chrome, Edge or Safari, but I think we can assume once they add it this will just work?

Thanks for your consideration! 