### PR TITLE
fix(modal): use grid for modal positioning and fix scrollability

### DIFF
--- a/src/components/AppModal.vue
+++ b/src/components/AppModal.vue
@@ -70,30 +70,26 @@ export default {
   width: 100%;
   height: 100%;
   background-color: rgba(0, 0, 0, 0.7);
-  display: table;
+  display: grid;
+  grid-template: 1fr auto 1fr / 1fr auto 1fr;
+  overflow: auto;
   transition: opacity 0.25s ease;
 }
 
 .modal-wrapper {
-  display: table-cell;
-  vertical-align: middle;
+  grid-area: 2 / 2 / 2 / 2;
 }
 
 .modal-container {
   position: relative;
   width: 80vw;
   max-width: 700px;
-  max-height: 90vh;
-  overflow-y: scroll;
-  margin: 0px auto;
   padding: 0px 50px 60px;
   background-color: #192d38;
   border-radius: 5px;
   box-shadow: 0 2px 20px rgba(0, 0, 0, 0.8);
   transition: all 0.3s ease;
   border: 1px solid black;
-  max-height: 100%;
-  overflow-y: scroll;
 
   @media screen and (max-width: 700px) {
     padding: 0px 20px 20px;


### PR DESCRIPTION
- the current modal didn't scroll at all when the screen height was
  less than the modal content. This commit fixes it permanently
  (and hopefully for all scenarios).
- the commit also removed table-based positioning in favour of
  grid for positioning the modal in the center of the screen.

Closes #66