### PR TITLE
Proposal: CSS nesting changes.

### DIFF
--- a/src/components/AppCode.vue
+++ b/src/components/AppCode.vue
@@ -28,65 +28,66 @@
       <div id="code" ref="code">
         <div v-if="showHtml">
           <p>
-            <<span class="cname">div </span>
-            <span class="cprop">class="parent"</span>>
-            <br>
+            &lt;<span class="cname">div</span>
+            <span class="cprop">class="parent"</span>&gt;
+            <br />
             <span v-if="childarea.length > 0">
               <span v-for="(child, i) in childarea" :key="child">
                 <span class="sp">
-                  <<span class="cname">div </span>
-                  <span class="cprop">class="div{{ i + 1 }}"</span>>
-                  </<span class="cname">div</span>>
+                  &lt;<span class="cname">div</span>
+                  <span class="cprop">&nbsp;class="div{{ i + 1 }}"</span>&gt;
+                  &lt;/<span class="cname">div</span>&gt;
                 </span>
-                <br>
+                <br />
               </span>
             </span>
             <span v-else>
-              <br>
+              <br />
             </span>
-            </<span class="cname">div</span>>
+            &lt;/<span class="cname">div</span>&gt;
           </p>
         </div>
         <div v-else>
           <p>
             <span class="cname">.parent</span> {
-            <br>
+            <br />
             <span class="sp">
               <span class="ckey">display</span>:
               <span class="cprop">grid</span>;
             </span>
-            <br>
+            <br />
             <span class="sp">
               <span class="ckey">grid-template-columns</span>:
               <span class="cprop">{{ colTemplate }}</span>;
             </span>
-            <br>
+            <br />
             <span class="sp">
               <span class="ckey">grid-template-rows</span>:
               <span class="cprop">{{ rowTemplate }}</span>;
             </span>
-            <br>
+            <br />
             <span class="sp">
               <span class="ckey">grid-column-gap</span>:
               <span class="cprop">{{ columngap }}px;</span>
             </span>
-            <br>
+            <br />
             <span class="sp">
               <span class="ckey">grid-row-gap</span>:
               <span class="cprop">{{ rowgap }}px</span>;
-            </span>
-            <br>
-            <span v-if="childarea.length > 0" class="child">
+            </span> 
+            <br />}
+          </p>
+          <p>
+            <span v-if="childarea.length > 0">
               <span v-for="(child, i) in childarea" :key="child">
                 <span>
                   <span class="cname">.div{{ i + 1 }}</span> {
                   <span class="ckey">grid-area</span>:
                   <span class="cprop">{{ child }}</span>; }
                 </span>
-                <br>
+                <br />
               </span>
             </span>
-            }
           </p>
         </div>
       </div>
@@ -137,7 +138,7 @@ export default {
       }
     },
     toggleHtml() {
-      this.showHtml = !this.showHtml
+      this.showHtml = !this.showHtml;
     }
   }
 };
@@ -188,7 +189,7 @@ export default {
   cursor: pointer;
 }
 
-.togglehtml{
+.togglehtml {
   position: absolute;
   right: 5px;
   bottom: 5px;

--- a/src/components/AppCode.vue
+++ b/src/components/AppCode.vue
@@ -30,7 +30,7 @@
           <p>
             &lt;<span class="cname">div</span>
             <span class="cprop">class="parent"</span>&gt;
-            <br />
+            <br>
             <span v-if="childarea.length > 0">
               <span v-for="(child, i) in childarea" :key="child">
                 <span class="sp">
@@ -38,11 +38,11 @@
                   <span class="cprop">&nbsp;class="div{{ i + 1 }}"</span>&gt;
                   &lt;/<span class="cname">div</span>&gt;
                 </span>
-                <br />
+                <br>
               </span>
             </span>
             <span v-else>
-              <br />
+              <br>
             </span>
             &lt;/<span class="cname">div</span>&gt;
           </p>
@@ -50,32 +50,32 @@
         <div v-else>
           <p>
             <span class="cname">.parent</span> {
-            <br />
+            <br>
             <span class="sp">
               <span class="ckey">display</span>:
               <span class="cprop">grid</span>;
             </span>
-            <br />
+            <br>
             <span class="sp">
               <span class="ckey">grid-template-columns</span>:
               <span class="cprop">{{ colTemplate }}</span>;
             </span>
-            <br />
+            <br>
             <span class="sp">
               <span class="ckey">grid-template-rows</span>:
               <span class="cprop">{{ rowTemplate }}</span>;
             </span>
-            <br />
+            <br>
             <span class="sp">
               <span class="ckey">grid-column-gap</span>:
               <span class="cprop">{{ columngap }}px;</span>
             </span>
-            <br />
+            <br>
             <span class="sp">
               <span class="ckey">grid-row-gap</span>:
               <span class="cprop">{{ rowgap }}px</span>;
             </span> 
-            <br />}
+            <br>}
           </p>
           <p>
             <span v-if="childarea.length > 0">
@@ -85,7 +85,7 @@
                   <span class="ckey">grid-area</span>:
                   <span class="cprop">{{ child }}</span>; }
                 </span>
-                <br />
+                <br>
               </span>
             </span>
           </p>


### PR DESCRIPTION
### Purpose
Proposing the removal of nested child divs in the css output as described in https://github.com/sdras/cssgridgenerator/issues/75

### Change Summary
I've changed the code box structure to reflect a closing of the parent div and line items for the children. Additionally, I have added HTML Encoded < and > characters to the HTML output, though I can make this an additional PR if we think it's scope creep :). I have also removed the 'child' CSS class from the children divs to pretty up the output now that the CSS isn't nested. The child class was adding 40px left padding to simulate indentation in the parent CSS.

### Additional Information
An example of the output code would be:
**Before**:
```css
.parent {
  display: grid;
  grid-template-columns: repeat(5, 1fr);
  grid-template-rows: repeat(5, 1fr);
  grid-column-gap: 0px;
  grid-row-gap: 0px;
  .div1 { grid-area: 1 / 1 / 4 / 5; }
  .div2 { grid-area: 2 / 5 / 3 / 6; }
  .div3 { grid-area: 2 / 5 / 4 / 6; }
}
```
**After:** 
```css
.parent {
  display: grid;
  grid-template-columns: repeat(5, 1fr);
  grid-template-rows: repeat(5, 1fr);
  grid-column-gap: 0px;
  grid-row-gap: 0px;
}
.div1 { grid-area: 1 / 1 / 4 / 5; }
.div2 { grid-area: 2 / 5 / 3 / 6; }
.div3 { grid-area: 2 / 5 / 4 / 6; }
```
Additional Sceenshots of the before and after changes are attached! (Screenshots taken in Chrome v77.0.3865.90, with a res of 1920x920)
![Before_cssgridIssue75](https://user-images.githubusercontent.com/24568908/66066860-5b955580-e518-11e9-8c08-65a2bc82c016.PNG)
![After_cssgridIssue75](https://user-images.githubusercontent.com/24568908/66066869-5f28dc80-e518-11e9-8fe9-dc137d50aeb7.PNG)


