### PR TITLE
Feature: CSS Selector, now with IE Compatibility mode!

### DIFF
--- a/src/components/AppCode.vue
+++ b/src/components/AppCode.vue
@@ -24,6 +24,11 @@
         <template v-if="codeWasCopied">{{ $t("modal.copy.clipboardSuccess") }}</template>
         <template v-else>{{ $t("modal.copy.clipboard") }}</template>
       </button>
+       <select v-if="!showHtml" id="csstype" v-model="cssType" class="cssselect">
+          <option value="css" selected="selected">CSS</option>
+          <option value="scss">SCSS</option>
+          <option value="iec">IE Compatible</option>
+        </select>
 
       <div id="code" ref="code">
         <div v-if="showHtml">
@@ -75,7 +80,8 @@
               <span class="ckey">grid-row-gap</span>:
               <span class="cprop">{{ rowgap }}px</span>;
             </span> 
-            <br>}
+            <br>
+            <span>}</span>
           </p>
           <p>
             <span v-if="childarea.length > 0">
@@ -103,7 +109,8 @@ export default {
   data() {
     return {
       codeWasCopied: false,
-      showHtml: false
+      showHtml: false,
+      cssType: "css"
     };
   },
   computed: {
@@ -187,6 +194,14 @@ export default {
   border-radius: 0 4px 0 4px;
   font-family: "Mukta Mahee", Helvetica, Arial, sans-serif;
   cursor: pointer;
+}
+
+.cssselect {
+  border-radius: 4px 4px 4px 4px;
+  font-family: "Mukta Mahee", Helvetica, Arial, sans-serif;
+  border-color:#08ffbd;
+  background-color:#131321;
+  color:#08ffbd;
 }
 
 .togglehtml {

--- a/src/components/AppCode.vue
+++ b/src/components/AppCode.vue
@@ -34,7 +34,7 @@
         <div v-if="showHtml">
           <p>
             &lt;<span class="cname">div</span>
-            <span class="cprop">class="parent"</span>&gt;
+            <span class="cprop">&nbsp;class="parent"</span>&gt;
             <br>
             <span v-if="childarea.length > 0">
               <span v-for="(child, i) in childarea" :key="child">
@@ -56,16 +56,37 @@
           <p>
             <span class="cname">.parent</span> {
             <br>
+            <template v-if="cssType==='iec'">
+              <span class="sp">
+                <span class="ckey">display</span>:
+                <span class="cprop">ms-grid</span>;
+              </span>
+              <br>
+            </template>
             <span class="sp">
               <span class="ckey">display</span>:
               <span class="cprop">grid</span>;
             </span>
             <br>
+             <template v-if="cssType==='iec'">
+              <span class="sp">
+                <span class="ckey">-ms-grid-columns</span>:
+                <span class="cprop">{{ msColTemplate }}</span>;
+              </span>
+              <br>
+            </template>
             <span class="sp">
               <span class="ckey">grid-template-columns</span>:
               <span class="cprop">{{ colTemplate }}</span>;
             </span>
             <br>
+             <template v-if="cssType==='iec'">
+              <span class="sp">
+                <span class="ckey">-ms-grid-rows</span>:
+                <span class="cprop">{{ msRowTemplate }}</span>;
+              </span>
+              <br>
+            </template>
             <span class="sp">
               <span class="ckey">grid-template-rows</span>:
               <span class="cprop">{{ rowTemplate }}</span>;
@@ -76,25 +97,62 @@
               <span class="cprop">{{ columngap }}px;</span>
             </span>
             <br>
+            <template v-if="cssType==='iec'">
+              <span class="sp">
+                <span class="ckey">margin-right</span>:
+                <span class="cprop">{{ msRowTemplate }}</span>;
+              </span>
+              <br>
+            </template>
             <span class="sp">
               <span class="ckey">grid-row-gap</span>:
               <span class="cprop">{{ rowgap }}px</span>;
             </span> 
             <br>
-            <span>}</span>
+            <span v-if="cssType==='css' || cssType ==='iec'">}</span>
           </p>
-          <p>
-            <span v-if="childarea.length > 0">
-              <span v-for="(child, i) in childarea" :key="child">
-                <span>
-                  <span class="cname">.div{{ i + 1 }}</span> {
-                  <span class="ckey">grid-area</span>:
-                  <span class="cprop">{{ child }}</span>; }
+          <p :class="{child : cssType==='scss'}">
+            <template v-if="cssType==='iec'">
+              <span v-if="mschildarea.length > 0">
+                <span v-for="(child, i) in mschildarea" :key="child.cString">
+                    <span class="cname">.div{{ i + 1 }}</span> {
+                    <br>
+                    <span class="ckey msc">-ms-grid-row</span>:
+                    <span class="cprop">{{ child.startRow }}</span>;&#9;
+                    <span class="ckey">-ms-grid-row-span</span>:
+                    <span class="cprop">{{ calculateMsSpan(child.startRow, child.endRow) }}</span>; 
+                    <br>
+                    <template v-if="rowgap > 0 || columngap > 0">
+                      <span class="ckey msc">margin</span>:
+                      <span class="cprop">{{ calculateMsMargin(columngap, rowgap) }}</span>;
+                      <br>
+                    </template>
+                    <span class="ckey msc">-ms-grid-column</span>:
+                    <span class="cprop">{{ child.startCol }}</span>; 
+                    <span class="ckey">-ms-grid-column-span</span>:
+                    <span class="cprop">{{ calculateMsSpan(child.startCol, child.endCol)  }}</span>; 
+                    <br>
+                    <span class="ckey msc">grid-area</span>:           
+                    <span class="cprop">{{ child.cString }}</span>; 
+                    <br>}
+                    <br>
                 </span>
-                <br>
               </span>
-            </span>
+            </template>
+            <template v-else>
+              <span v-if="childarea.length > 0">
+                <span v-for="(child, i) in childarea" :key="child">
+                  <span>
+                    <span class="cname">.div{{ i + 1 }}</span> {
+                    <span class="ckey">grid-area</span>:
+                    <span class="cprop">{{ child }}</span>; }
+                  </span>
+                  <br>
+                </span>
+              </span>
+            </template>
           </p>
+          <span v-if="cssType==='scss'">}</span>
         </div>
       </div>
       <!--code-->
@@ -114,8 +172,8 @@ export default {
     };
   },
   computed: {
-    ...mapState(["columngap", "rowgap", "childarea"]),
-    ...mapGetters(["rowTemplate", "colTemplate"])
+    ...mapState(["columngap", "rowgap", "childarea", "mschildarea"]),
+    ...mapGetters(["rowTemplate", "colTemplate", "msColTemplate", "msRowTemplate"])
   },
   methods: {
     copy() {
@@ -146,6 +204,20 @@ export default {
     },
     toggleHtml() {
       this.showHtml = !this.showHtml;
+    },
+    calculateMsMargin(colgap, rowgap){
+      let bottom = rowgap > 0 ? `${rowgap}px` : 0,
+          right = colgap > 0 ? `${colgap}px` : 0;
+      
+      return `0 ${right} ${bottom} 0`;
+    },
+    calculateMsSpan(start, end){
+      let initialSpan = end - start;
+      if( initialSpan <= 1){
+        return 1;
+      } else {
+        return initialSpan;
+      }
     }
   }
 };
@@ -213,7 +285,11 @@ export default {
 }
 
 .child {
-  padding-left: 40px;
+  padding-left: 20px;
+}
+
+.msc {
+  padding-left:20px;
 }
 
 .codegroup {

--- a/src/components/AppGrid.vue
+++ b/src/components/AppGrid.vue
@@ -148,8 +148,9 @@ export default {
 
         let childstring = `${startRow} / ${startCol} / ${endRow +
           1} / ${endCol + 1}`;
+        let childobject = {startRow, startCol, endRow: endRow + 1, endCol: endCol + 1, cString: childstring};
 
-        this.$store.commit("addChildren", childstring);
+        this.$store.commit("addChildren", childobject);
       }
     },
     removeChild(index) {

--- a/src/store.js
+++ b/src/store.js
@@ -12,16 +12,25 @@ export default new Vuex.Store({
     rowgap: 0,
     colArr: [],
     rowArr: [],
-    childarea: []
+    childarea: [],
+    mschildarea:[]
   },
   getters: {
     colTemplate(state) {
       const unitGroups = groupRepeatedUnits(state.colArr);
       return createRepetition(unitGroups);
     },
+    msColTemplate(state){
+      let colUnits = state.colArr.map(col=>col.unit);
+        return colUnits.join(" ");
+    },
     rowTemplate(state) {
       const unitGroups = groupRepeatedUnits(state.rowArr);
       return createRepetition(unitGroups);
+    },
+    msRowTemplate(state){
+      let rowUnits = state.rowArr.map(row=>row.unit);
+        return rowUnits.join(" ");
     },
     divNum(state) {
       return state.columns * state.rows;
@@ -35,7 +44,6 @@ export default new Vuex.Store({
     adjustArr(state, payload) {
       let newVal = Number(payload.newVal),
         oldVal = Number(payload.oldVal);
-
       if (newVal < oldVal) {
         // you'd think that .length would be quicker here, but it doesn't trigger the getter/computed in colTemplate etc.
         let difference = oldVal - newVal;
@@ -50,10 +58,13 @@ export default new Vuex.Store({
       }
     },
     addChildren(state, payload) {
-      state.childarea.push(payload);
+      let childstring = `${payload.startRow} / ${payload.startCol} / ${payload.endRow } / ${payload.endCol}`;
+      state.childarea.push(childstring);
+      state.mschildarea.push(payload);
     },
     removeChildren(state, payload) {
       state.childarea.splice(payload, 1);
+      state.mschildarea.splice(payload, 1);
     },
     updateColumns(state, payload) {
       state.columns = payload;
@@ -69,6 +80,7 @@ export default new Vuex.Store({
     },
     resetGrid(state, payload) {
       state.childarea = [];
+      state.mschildarea=[];
     }
   }
 });


### PR DESCRIPTION
### Purpose
This feature request is proposed to solve a couple issues:

1. Solves #40 , CSS Generation for IE
2. Adds features that resolve some discussion on #76 namely, the debate over showing vanilla CSS vs. SCSS syntax. We can now have our 🍰 and eat it too!

I would really love for someone who is much more of an expert on ms-grid to take a look at my css outputs and validate they are the way these should be implemented :).

### Change Summary

- Added a Dropdown and data object control to select the CSS output type, CSS (Default), SCSS or IE Compatible. 
- Added v-if conditions to change display for SCSS nesting of child components.
- Added IE Compatible CSS generation and accompanying conditional elements
- Added methods to compute ms-grid span and margin values
- Modified Vuex to add state objects for ms grid templates and modified mutations to populate the objects
- Modified grid component to pass grid values as an object into vuex for manipulation into ms-grid

### Notes
I was trying to get creative with formatting to save screen real estate, very open to suggestions on how to pretty this up. I also took liberties with the styling for the dropdown menu for CSS selection. Please let me know how we can make these look better!

### Examples
Here is an example of what the changes look like. Here is the example grid:
![startinggrid](https://user-images.githubusercontent.com/24568908/66248700-0021be00-e6f8-11e9-958a-35436064aff3.PNG)

**Vanilla CSS:**
![cssgridcss](https://user-images.githubusercontent.com/24568908/66248756-e9c83200-e6f8-11e9-8d69-33269ce1f0a8.PNG)

**SCSS:**
![cssgridscss](https://user-images.githubusercontent.com/24568908/66248801-25fb9280-e6f9-11e9-9173-83cf5e4477ae.PNG)

**IE Compatibility:**
![cssgridie](https://user-images.githubusercontent.com/24568908/66248832-7541c300-e6f9-11e9-97af-b6801a18c072.PNG)


