### PR TITLE
Shareable states / Add query param support for URL sharing

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -20,7 +20,7 @@ export default {
     AppForm
   },
   created() {
-    this.$store.commit("initialArrIndex");
+    this.$store.commit("initialArrIndex", window.location.search);
   }
 };
 </script>

--- a/src/store.js
+++ b/src/store.js
@@ -28,9 +28,25 @@ export default new Vuex.Store({
     }
   },
   mutations: {
-    initialArrIndex(state) {
-      createArr(state.columns, state.colArr);
-      createArr(state.rows, state.rowArr);
+    initialArrIndex(state, payload) {
+      if(payload !== '') {
+        const queryParams = new URLSearchParams(payload)
+
+        for (const stateKey in state) {
+          const paramIsValid = queryParams.has(stateKey)
+          const paramType = typeof(state[stateKey])
+
+          if(paramIsValid && paramType === 'number') {
+            state[stateKey] = queryParams.get(stateKey);
+          }
+          else if (paramIsValid && paramType === 'object') {
+            state[stateKey] = JSON.parse(queryParams.get(stateKey))
+          }
+        }
+      } else {
+          createArr(state.columns, state.colArr);
+          createArr(state.rows, state.rowArr);
+      }
     },
     adjustArr(state, payload) {
       let newVal = Number(payload.newVal),


### PR DESCRIPTION
This is related to #16. Created this pr because the issue is idled since June.

## Feature
Enable to share the store state in url query string. 

Once pr preview of netlifly is deployed theese examples bellow should be working:
 - [url change default columns and rows  -> /?columns=3&rows=4](https://deploy-preview-83--cssgrid-generator.netlify.com/?columns=3&rows=4&colArr=[{%22unit%22:%221fr%22},%20{%22unit%22:%221fr%22},{%22unit%22:%221fr%22}]&rowArr=[{%22unit%22:%221fr%22},%20{%22unit%22:%221fr%22},{%22unit%22:%221fr%22},{%22unit%22:%221fr%22}])
 - [url change units](https://deploy-preview-83--cssgrid-generator.netlify.com/?columns=3&rows=4&colArr=[{%22unit%22:%222fr%22},%20{%22unit%22:%22100px%22},{%22unit%22:%221fr%22}]&rowArr=[{%22unit%22:%221fr%22},%20{%22unit%22:%221fr%22},{%22unit%22:%221fr%22},{%22unit%22:%221fr%22}])
 - [url with preseted childareas](https://deploy-preview-83--cssgrid-generator.netlify.com/?columns=3&rows=4&colArr=[{%22unit%22:%222fr%22},%20{%22unit%22:%2250px%22},{%22unit%22:%221fr%22}]&rowArr=[{%22unit%22:%222fr%22},%20{%22unit%22:%2230px%22},{%22unit%22:%221fr%22},{%22unit%22:%221fr%22}]&childarea=[%221%20/%201%20/%203%20/%203%22,%222%20/%202%20/%204%20/%204%22,%224%20/%201%20/%205%20/%202%22])

## How to use
Add the desired state as a query parameter `/?columns=3&colArr=[{"unit":"1fr"},{"unit":"1fr"},{"unit":"1fr"}]`

## Notes
- `rows`, `columns`, `colArr` and `rowArr` should be always setted
- Just used `window.location.search` and `URLSearchParams`. Maybe considering to add vue-router to the project?
- Did not created a share action to the user. I could add this if you want.