### PR TITLE
Fixed issue with negative row/column numbers

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -24,7 +24,7 @@ export default new Vuex.Store({
       return createRepetition(unitGroups);
     },
     divNum(state) {
-      return state.columns * state.rows;
+      return Math.max(state.columns, 0) * Math.max(state.rows, 0);
     }
   },
   mutations: {
@@ -33,8 +33,8 @@ export default new Vuex.Store({
       createArr(state.rows, state.rowArr);
     },
     adjustArr(state, payload) {
-      let newVal = Number(payload.newVal),
-        oldVal = Number(payload.oldVal);
+      let newVal = Math.max(Number(payload.newVal), 0),
+        oldVal = Math.max(Number(payload.oldVal), 0);
 
       if (newVal < oldVal) {
         // you'd think that .length would be quicker here, but it doesn't trigger the getter/computed in colTemplate etc.


### PR DESCRIPTION
### Bug
I saw an interesting issue when you enter negative numbers in columns or rows.
The grid becomes empty, but if you then enter a positive number, it adds that positive of the negative number you previously entered to it. Hard to explain in words. Better explained with an example

If I enter -3 in the columns, I get an empty grid, as can be reasonably expected

![image](https://user-images.githubusercontent.com/23285466/69012630-8e1ad680-093d-11ea-89e5-969e3e703a0a.png)

Now, if I then enter a positive number, say 7, to it, I get that number plus three columns. In this case, entering 7 results in 10 columns.

![image](https://user-images.githubusercontent.com/23285466/69012649-b4d90d00-093d-11ea-9153-7555627bce79.png)

The same thing happens with rows.

### Cause
This happens because in the [adjustArr](https://github.com/sdras/cssgridgenerator/blob/master/src/store.js#L35) function in the store.js file, it takes the difference of oldVal and newVal, and if the oldVal is negative, it'll add that to the newVal and result in an incorrect number of columns.

### Fix
Put a minimum value of 0 on the oldVal and newVal variables in the adjustArr function. 
Also, need a minimum value of 0 in divNum's calculations in case 'columns' and/or 'rows' is negative

The first solution I thought of was to put a minimum value of 0 for columns and rows in [updateColumns](https://github.com/sdras/cssgridgenerator/blob/master/src/store.js#L58) and [updateRows](https://github.com/sdras/cssgridgenerator/blob/master/src/store.js#L61) respectively in store.js. But that automatically changes the value the user just entered from, say, -3 to 0 in the UI. I wasn't a fan of changing a user-entered value, even if invalid, so I thought the other solution was better.