### PR TITLE
Use the modern names for column-gap/row-gap as they got renamed in a early version of the spec.

### DIFF
--- a/src/components/AppCode.vue
+++ b/src/components/AppCode.vue
@@ -67,12 +67,12 @@
             </span>
             <br>
             <span class="sp">
-              <span class="ckey">grid-column-gap</span>:
+              <span class="ckey">column-gap</span>:
               <span class="cprop">{{ columngap }}px;</span>
             </span>
             <br>
             <span class="sp">
-              <span class="ckey">grid-row-gap</span>:
+              <span class="ckey">row-gap</span>:
               <span class="cprop">{{ rowgap }}px</span>;
             </span> 
             <br>}


### PR DESCRIPTION
Fixes #144